### PR TITLE
Add ISO-8601 to unix converter

### DIFF
--- a/orka-utils.h
+++ b/orka-utils.h
@@ -2,15 +2,16 @@
 #define ORKA_UTILS_H
 
 #include <stddef.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-
 extern char *
 orka_load_whole_file(const char filename[], size_t *len);
 
+long long iso8601_to_unix_ms(const char *timestamp);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds a function inside orca-utils.h to convert ISO-8601 timestamp to UNIX timestamp in milliseconds.