### PR TITLE
Changed ISO-8601 to unix conversion to orka's json-scanf convention

### DIFF
--- a/orka-utils.c
+++ b/orka-utils.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "orka-utils.h"
 #include <math.h>
+#include <time.h>
 
 char*
 orka_load_whole_file(const char filename[], size_t *len)
@@ -81,7 +82,7 @@ list(void ** p, size_t n, char * path)
   return total_files;
 }
 
-long long iso8601_to_unix_ms(const char *timestamp)
+int orka_iso8601_to_unix_ms(char *timestamp, size_t s, void *p)
 {
   struct tm tm;
   double seconds = 0;
@@ -89,12 +90,24 @@ long long iso8601_to_unix_ms(const char *timestamp)
   int tz_hour = 0;
   int tz_min = 0;
   long long result = 0;
+  long long *recipient = (long long*) p;
+  char *buf = NULL;
   memset(&tm, 0, sizeof(tm));
 
-  sscanf(timestamp, "%d-%d-%dT%d:%d:%lf%c%d:%d", // ISO-8601 complete format
+  /* Creating a temporary buffer and copying the string, because
+  sscanf receives a null-terminated string, and there's not
+  "snscanf" or something like that */
+  buf = malloc(s + 1);
+  if(!buf) return 0;
+  memcpy(buf, timestamp, s);
+  buf[s] = '\0';
+
+  sscanf(buf, "%d-%d-%dT%d:%d:%lf%c%d:%d", // ISO-8601 complete format
   &tm.tm_year, &tm.tm_mon, &tm.tm_mday, // Date
   &tm.tm_hour, &tm.tm_min, &seconds, // Time
   &tz_operator, &tz_hour, &tz_min); // Timezone
+
+  free(buf);
 
   tm.tm_mon--; // struct tm takes month from 0 to 11, instead of 1 to 12
   tm.tm_year -= 1900; // struct tm takes years from 1900
@@ -116,5 +129,7 @@ long long iso8601_to_unix_ms(const char *timestamp)
       break;
   }
 
-  return result;
+  *recipient = result;
+
+  return 1;
 }

--- a/orka-utils.h
+++ b/orka-utils.h
@@ -2,7 +2,6 @@
 #define ORKA_UTILS_H
 
 #include <stddef.h>
-#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,7 +10,7 @@ extern "C" {
 extern char *
 orka_load_whole_file(const char filename[], size_t *len);
 
-long long iso8601_to_unix_ms(const char *timestamp);
+int orka_iso8601_to_unix_ms(char *timestamp, size_t s, void *p);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Followed stensalweb's suggestions to improve "iso8601_to_unix_ms", that now is called "orka_iso8601_to_unix_ms".