### PR TITLE
Remove unnecessary username verification.

### DIFF
--- a/bot-echo.cpp
+++ b/bot-echo.cpp
@@ -23,9 +23,6 @@ void on_message_create(
   // make sure bot doesn't echoes other bots
   if (msg->author->bot)
     return;
-  // make sure it doesn't echoes itself
-  if (0 == strcmp(me->username, msg->author->username))
-    return;
 
   message::create::params params = {
     .content = (char*)msg->content //this won't be modified

--- a/bot-pin.cpp
+++ b/bot-pin.cpp
@@ -22,9 +22,6 @@ void on_message_create(
   // make sure bot ignores msgs from other bots
   if (msg->author->bot)
     return;
-  // make sure it ignores itself
-  if (0 == strcmp(me->username, msg->author->username))
-    return;
 
   if (strstr(msg->content, "pin me")) 
     channel::pin_message(client, msg->channel_id, msg->id);

--- a/bot-ping-pong.cpp
+++ b/bot-ping-pong.cpp
@@ -22,9 +22,6 @@ void on_message_create(
   // make sure bot doesn't echoes other bots
   if (msg->author->bot)
     return;
-  // make sure it doesn't echoes itself
-  if (0 == strcmp(me->username, msg->author->username))
-    return;
 
   message::create::params params = {0};
   if (0 == strcmp(msg->content, "ping"))


### PR DESCRIPTION
I removed unnecessary username verification because of two reasons:
1 - If the author is not the bot, it's also no the client, obviously.
2 - If an user had the same username of the bot, his messages would be ignored, because of the discriminator not being compared. But this could be easily solved by comparing IDs, so the most important reason is the first one.