### PR TITLE
Changed (long long*) casting to (int64_t*) casting inside orka_iso8601_to_unix_ms and changed size_t declaration from NULL to 0.

### DIFF
--- a/orka-utils.c
+++ b/orka-utils.c
@@ -12,7 +12,7 @@
 char*
 orka_load_whole_file(const char filename[], size_t *len)
 {
-  size_t size = NULL;
+  size_t size = 0;
   FILE *f = fopen(filename,"rb");
   if (!f) {
     char *s = strerror(errno);
@@ -90,7 +90,7 @@ int orka_iso8601_to_unix_ms(char *timestamp, size_t s, void *p)
   int tz_hour = 0;
   int tz_min = 0;
   int64_t result = 0;
-  int64_t *recipient = (long long*) p;
+  int64_t *recipient = (int64_t*) p;
   char *buf = NULL;
   memset(&tm, 0, sizeof(tm));
 


### PR DESCRIPTION
In this PR, I changed two things:

1 - A "size_t" variable was declared as "NULL", which is for pointers, so that caused compiling warnings.

2 - Inside orka_iso8601_to_unix_ms, it was casting "p" to "long long*" instead of "int64_t*".