### PR TITLE
Add stdint.h include to libdiscord.h

### DIFF
--- a/libdiscord.h
+++ b/libdiscord.h
@@ -1,6 +1,7 @@
 #ifndef LIBDISCORD_H_
 #define LIBDISCORD_H_
 
+#include <stdint.h>
 #include "discord-common.h"
 
 /* This is the version number of the package from which this header


### PR DESCRIPTION
I had a problem when building the latest version on Windows, my compiler wasn't recognizing `uint64_t`, so I added `<stdint.h>` include header to `libdiscord.h`.