### PR TITLE
Add init, cleanup and json_load functions to message::reference

### DIFF
--- a/discord-public-channel.cpp
+++ b/discord-public-channel.cpp
@@ -309,6 +309,37 @@ del(client *client, const uint64_t channel_id, const uint64_t message_id)
     "/channels/%llu/messages/%llu", channel_id, message_id);
 }
 
+namespace reference {
+
+dati*
+init()
+{
+  dati *new_reference = (dati*)calloc(1, sizeof(dati));
+  return new_reference;
+}
+
+void
+cleanup(dati *reference)
+{
+  free(reference);
+}
+
+void
+json_load(char *str, size_t len, void *p_reference)
+{
+  dati *reference = (dati*)p_reference;
+
+  json_scanf(str, len,
+     "[message_id]%F"
+     "[channel_id]%F"
+     "[guild_id]%F",
+      &orka_strtoull, &reference->message_id,
+      &orka_strtoull, &reference->channel_id,
+      &orka_strtoull, &reference->guild_id);
+}
+
+}
+
 } // namespace message
 
 } // namespace channel

--- a/libdiscord.h
+++ b/libdiscord.h
@@ -187,7 +187,9 @@ struct dati {
   uint64_t guild_id;
 };
 
-//@todo missing initialization functions
+dati *init();
+void cleanup(dati *reference);
+void json_load(char *str, size_t len, void *p_reference);
 
 } // namespace reference
 


### PR DESCRIPTION
Add `init`, `cleanup` and `json_load` functions to `message::reference`