### PR TITLE
n1612916658

### DIFF
--- a/test/test-api.cpp
+++ b/test/test-api.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 
   guild::dati **guilds = user::me::get_guilds(client);
   for (size_t i=0; guilds[i]; ++i) {
-    D_PRINT("%lu", guilds[i]->id);
+    D_PRINT("%llu", guilds[i]->id);
   }
 
   guild::list_cleanup(guilds);

--- a/test/test-json-scanf-E.c
+++ b/test/test-json-scanf-E.c
@@ -22,8 +22,10 @@ int main () {
   char * json_str = NULL;
   json_asprintf(&json_str, (char *)test_str);
 
+  fprintf (stderr, "%s\n", json_str);
+
   int ret = json_scanf(json_str, strlen(json_str),
-                       "[i]%d [f]%f  [b]%b [s]%20s %E",
+                       "[i]:d [f]:f  [b]:b [s]:20s :E",
                        &x.i, &x.f, &x.b, x.s, &x.E);
 
   free(json_str);

--- a/test/test-json-scanf-array.c
+++ b/test/test-json-scanf-array.c
@@ -63,12 +63,12 @@ struct tree_node {
 void load_tree_node(char * str, size_t len, void * p) {
   struct tree_node * n = (struct tree_node *)p;
   json_scanf(str, len,
-             "[path]%?s"
-             "[mode]%?s"
-             "[type]%?s"
-             "[size]%d"
-             "[sha]%?s"
-             "[url]%?s",
+             "[path]:.+s"
+             "[mode]:.+s"
+             "[type]:.+s"
+             "[size]:d"
+             "[sha]:.+s"
+             "[url]:.+s",
              &n->path,
              &n->mode,
              &n->type,
@@ -129,9 +129,9 @@ int main()
 
   char * json_str = NULL;
   int s = json_asprintf(&json_str, test_string);
-  //printf("%s\n", json_str);
+  printf("%s\n", json_str);
   struct sized_buffer array_tok = { .start = NULL, .size = 0 };
-  json_scanf(json_str, s, "[tree]%T", &array_tok);
+  json_scanf(json_str, s, "[tree]:T", &array_tok);
   printf("json_array_string:\n%.*s\n", (int)array_tok.size, array_tok.start);
 
   jsmn_parser parser;
@@ -147,18 +147,18 @@ int main()
 
   int i;
 
-  printf("test []%%L\n");
+  printf("test []:L\n");
   struct sized_buffer ** tokens = NULL;
-  json_scanf(array_tok.start, array_tok.size, "[]%L", &tokens);
+  json_scanf(array_tok.start, array_tok.size, "[]:L", &tokens);
   for (i = 0; tokens[i]; i++) {
     printf("token [%p, %zu]\n", tokens[i]->start, tokens[i]->size);
     printf("token %.*s\n", (int)tokens[i]->size, tokens[i]->start);
   }
   free(tokens);
 
-  printf("test [tree]%%L\n");
+  printf("test [tree]:L\n");
   tokens = NULL;
-  json_scanf(json_str, s, "[tree]%L", &tokens);
+  json_scanf(json_str, s, "[tree]:L", &tokens);
   struct tree_node ** nodes =
     (struct tree_node **) ntl_fmap((void **)tokens, sizeof(struct tree_node), NULL);
   for (i = 0; tokens[i]; i++) {
@@ -232,7 +232,7 @@ int main()
   ntl_free(nodes, free_tree_node);
 
   fprintf(stdout, "test json_array_str_to_ntl with %%F\n");
-  json_scanf(json_str, s, "[tree]%F", orka_str_to_ntl, &deserializer);
+  json_scanf(json_str, s, "[tree]:F", orka_str_to_ntl, &deserializer);
   wsize = json_asprintf(&b, "{|a|:|%s|, |b|:%d, |x|:%F }", "abc",
                         10, print_all, nodes);
   fprintf(stdout, "%d %s\n", wsize, b);

--- a/test/test-json-scanf.c
+++ b/test/test-json-scanf.c
@@ -56,10 +56,10 @@ int main(void)
   struct sized_buffer tok;
 
   json_scanf(str, strlen(str),
-       "[a1][0]%d [t]%s [s]%d [op]%d [nstr]%s [k1][v1]%d [b]%b"
-       "[bigs]%.*s"
-       "[bigs]%.*S"
-       "[k1]%T"
+             "[a1][0]:d [t]:s [s]:d [op]:d [nstr]:s [k1][v1]:d [b]:b"
+               "[bigs]:.*s"
+               "[bigs]:.*S"
+               "[k1]:T"
        ,&i4, str1, &integer1, &integer2, str2, &i3, &i5
           ,128 /* size of bigs */, bigs
           ,128 /* size of bigS */, bigS
@@ -70,7 +70,7 @@ int main(void)
          str1, integer1, integer2, str2, i3, i4, bigs, bigS);
 
   char * p = NULL, *q = NULL;
-  json_scanf(str, strlen(str), "[bigs]%?s [bigs]%?S", &p, &q);
+  json_scanf(str, strlen(str), "[bigs]:.+s [bigs]:.+S", &p, &q);
   if (p) {
     printf("unknown string size: bigs %s\n", p);
     free(p);
@@ -89,13 +89,13 @@ int main(void)
   snprintf(t_str, 128, "{ \"key\":\"%s\", \"a\":10 }", raw_str);
   char * px = NULL;
   printf("%s\n", t_str);
-  json_scanf(t_str, strlen(t_str), "[key]%?s", &px);
+  json_scanf(t_str, strlen(t_str), "[key]:.+s", &px);
   printf("%s\n", px);
 
 
   snprintf(t_str, 128, "{ \"key\":\"%s\", \"a\":10 }", "XXXXXXXXX");
   printf("%s\n", t_str);
-  json_scanf(t_str, strlen(t_str), "[key]%?s", &px);
+  json_scanf(t_str, strlen(t_str), "[key]:.+s", &px);
   printf("%s\n", px);
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
use ':' instead of '%' to differentiate the format strings that are used to extract json values 