### PR TITLE
Add webhook name limit

### DIFF
--- a/libdiscord.h
+++ b/libdiscord.h
@@ -39,6 +39,10 @@ https://discord.com/developers/docs/resources/channel#embed-limits*/
 #define EMBED_FOOTER_TEXT_LEN 2048 + 1
 #define EMBED_AUTHOR_NAME_LEN 256 + 1
 
+/* WEBHOOK LIMITS
+https://discord.com/developers/docs/resources/webhook#create-webhook*/
+#define WEBHOOK_NAME_LEN 80 + 1
+
 /* SNOWFLAKES
 https://discord.com/developers/docs/reference#snowflakes */
 #define SNOWFLAKE_INCREMENT           12
@@ -1140,7 +1144,7 @@ struct dati {
   uint64_t guild_id;
   uint64_t channel_id;
   user::dati *user;
-  char *name; //@todo find fixed size limit
+  char name[WEBHOOK_NAME_LEN];
   char *avatar; //@todo find fixed size limit
   char *token; //@todo find fixed size limit
   uint64_t application_id;


### PR DESCRIPTION
Add webhook name limit: I added the `Create Webhook` link as URL that specifies the limits because there's no `Webhook Limits` or something like that on discord documentations, but the name limit (80) is specified in the `Create Webhook` section.

And, it cannot contain "clyde" inside the string. Cannot either be "aclydef", or "Clyde", even if it's uppercase. This detection is something we should do when adding the feature to create the webhook.