### PR TITLE
n1613073551

### DIFF
--- a/json-actor.c
+++ b/json-actor.c
@@ -453,6 +453,9 @@ char * parse_apath_value(struct stack *stack,
 {
   // until find a ']' or '\0'
   char * const start_pos = pos, * const end_pos = pos + size;
+
+  ASSERT_S('[' == *pos, "expecting '['");
+  pos ++;
   while (*pos && pos < end_pos) {
     if (']' == *pos) break;
     ++pos;
@@ -475,7 +478,6 @@ char * parse_apath_value(struct stack *stack,
   switch (*pos) {
     case '[':
     {
-      ++pos; // eat up '['
       struct apath *next_path = calloc(1, sizeof(struct apath));
       curr_path->next = next_path;
       return parse_apath_value(stack, pos, end_pos - pos, av, next_path);
@@ -517,7 +519,6 @@ parse_apath_value_list(struct stack * stack, char * pos, size_t size,
   while (*pos && pos < end_pos) {
     SKIP_SPACES(pos, end_pos);
     if ('[' == *pos) {
-      ++pos; //eat up '['
       pos = parse_apath_value(stack, pos, end_pos - pos,
                               pairs->pos + i, &pairs->pos[i].path);
     }

--- a/test/test-json-actor.c
+++ b/test/test-json-actor.c
@@ -7,7 +7,7 @@ int main ()
   char * next_pos;
   parse_value(&stack, "d", strlen("d"), &value, &next_pos);
 
-  char * t = "k]:d";
+  char * t = "[k]:d";
   struct apath_value kv;
   memset(&kv, 0, sizeof (struct apath_value));
   parse_apath_value(&stack, t, strlen(t), &kv, &kv.path);
@@ -19,13 +19,13 @@ int main ()
   if (is_primitive(t, strlen(t), &p)) {
     fprintf (stderr, "is primitive\n");
   }
-  t = "k]:\" aaaaaa \"";
+  t = "[k]:\" aaaaaa \"";
   parse_apath_value(&stack, t, strlen(t), &kv, &kv.path);
   print_apath_value(&kv);
 
   struct complex_value cv;
   memset(&cv, 0, sizeof(struct complex_value));
-  t = "{ [k] : d }";
+  t = "{ [k] : d  [n]: 102  [f]: 102.30 }";
   parse_expr(&stack, t, strlen(t), &cv);
   fprintf (stderr, "\n");
   print_complex_value(&cv);
@@ -70,7 +70,7 @@ int main ()
 
 
   memset(&cv, 0, sizeof(struct complex_value));
-  t = "[ true false true ] .E";
+  t = "[true false true null] .E";
   parse_expr(&stack, t, strlen(t), &cv);
   fprintf (stderr, "\n");
   print_complex_value(&cv);
@@ -84,7 +84,7 @@ int main ()
 
 
   memset(&cv, 0, sizeof(struct complex_value));
-  t = "{ [k1]:d  [k2]:true [k3]:f [k4]:F [k5]:[L] [k6]:T [k7]:{ [k8]:T } } .E";
+  t = "{ [k1]:d  [k2]:true [k3]:f [k4]:F [k5]:[L] [k6]:T [k7]:{ [k8]:T } [k9]:null } .E";
   parse_expr(&stack, t, strlen(t), &cv);
   fprintf (stderr, "\n");
   print_complex_value(&cv);


### PR DESCRIPTION
move the advance of position to parse_apath_value so the test input is a well formed string, and this will also improve the clarity of the code