### PR TITLE
Increase prefix max length

### DIFF
--- a/discord-common.h
+++ b/discord-common.h
@@ -310,7 +310,7 @@ struct dati { /* WEBSOCKETS STRUCTURE */
 
   session::dati session;
 
-  char prefix[5]; //if set will execute message.command callback
+  char prefix[32]; //if set will execute message.command callback
 
   struct { /* CALLBACKS STRUCTURE */
     idle_cb *on_idle;   //triggers in every event loop iteration


### PR DESCRIPTION
Increased max prefix length from 5 to 32.
Reasons: let's suppose there's a bot called `Potato` and it's developer choosed to use `potato.` as prefix, lilke `potato.help`, `potato.clear` etc. It won't fit into 5 characters (or 4, because of the null-terminated one).