### PR TITLE
Add default_message_notification_level to discord-common.h and use code instead of int

### DIFF
--- a/discord-common.h
+++ b/discord-common.h
@@ -60,6 +60,7 @@ namespace channel {
 namespace emoji { struct dati; }
 namespace guild {
   struct dati; 
+  namespace default_message_notification_level { typedef int code; }
   namespace explicit_content_filter_level { typedef int code; }
   namespace mfa_level { typedef int code; }
   namespace verification_level { typedef int code; }

--- a/libdiscord.h
+++ b/libdiscord.h
@@ -173,7 +173,7 @@ struct dati {
    int mfa_level;
    int verification_level;
    int explicit_content_filter;
-   int default_message_notifications;
+   guild::default_message_notification_level::code default_message_notifications;
    char vanity_url_code[MAX_URL_LEN];
   //@todo missing add
   //@todo missing remove
@@ -680,7 +680,7 @@ struct dati {
   bool widget_enabled;
   uint64_t widget_channel_id;
   verification_level::code verification_level;
-  int default_message_notifications;
+  guild::default_message_notification_level::code default_message_notifications;
   explicit_content_filter_level::code explicit_content_filter;
   //@todo missing roles;
   emoji::dati **emojis; //@todo add to from_json


### PR DESCRIPTION
Add `default_message_notification_level` to `discord-common.h` and use `code` instead of `int`