### PR TITLE
n1613531110

### DIFF
--- a/test/test-json-injector.c
+++ b/test/test-json-injector.c
@@ -61,7 +61,10 @@ int main () {
   fprintf(stderr, "%s\n", bigbuf);
 
   json_inject(bigbuf, sizeof(bigbuf), "[ F ]", &foobar, &i);
-  fprintf(stderr, "%s\n", bigbuf);
+  fprintf(stderr, "[ F ] > %s\n", bigbuf);
+
+  json_inject(bigbuf, sizeof(bigbuf), "[ |F| ]", &foobar, &i);
+  fprintf(stderr, "[ |F| ] > %s\n", bigbuf);
 
   json_inject(bigbuf, sizeof(bigbuf),
               "(k1) : s"


### PR DESCRIPTION
feat: support `|F|`, no spaces is allowed, this will keep the C value to JSON string conversion without adding double quotes to enclose the result