### PR TITLE
fix: remove @todo and add timezone addition inside orka_unix_ms_to_iso8601, use |F| inside embed::to_json

### DIFF
--- a/discord-public-channel.cpp
+++ b/discord-public-channel.cpp
@@ -635,7 +635,7 @@ to_json(char *str, size_t len, void *p_embed)
                         "(type):s"
                         "(description):s"
                         "(url):s"
-                        "(timestamp):F"
+                        "(timestamp):|F|"
                         "(color):d"
                         "(footer):F"
                         "(image):F"

--- a/orka-utils.c
+++ b/orka-utils.c
@@ -140,9 +140,9 @@ orka_unix_ms_to_iso8601(char *str, size_t len, void *p_data)
   time_t seconds = timestamp / 1000;
   int millis = timestamp % 1000;
 
+  seconds += timezone;
   struct tm *tm = localtime(&seconds);
 
-  // @todo find a better solution, like fix json_inject and use (timestamp):|F|
   return snprintf(str, len,
     "%d-%.2d-%dT%.2d:%.2d:%.2d.%.3dZ", // ISO-8601 complete format
     tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, // Date


### PR DESCRIPTION
fix: remove `@todo` and add timezone addition inside `orka_unix_ms_to_iso8601`, use `|F|` inside `embed::to_json`
Please, use `Merge Squash`.