### PR TITLE
n1613874589

### DIFF
--- a/discord-public-guild.cpp
+++ b/discord-public-guild.cpp
@@ -102,6 +102,7 @@ void
 list_from_json(char *str, size_t len, void *p_guilds)
 {
   struct ntl_deserializer d;
+  memset(&d, 0, sizeof(d));
   d.elem_size = sizeof(dati);
   d.init_elem = &init_dati;
   d.elem_from_buf = &from_json;
@@ -218,7 +219,8 @@ from_json(char *str, size_t len, void *p_member)
 void
 list_from_json(char *str, size_t len, void *p_members)
 {
-  struct ntl_deserializer d; 
+  struct ntl_deserializer d;
+  memset(&d, 0, sizeof(d));
   d.elem_size = sizeof(dati);
   d.init_elem = &init_dati;
   d.elem_from_buf = &from_json;
@@ -346,6 +348,7 @@ void
 list_from_json(char *str, size_t len, void *p_bans)
 {
   struct ntl_deserializer d;
+  memset(&d, 0, sizeof(d));
   d.elem_size = sizeof(dati);
   d.init_elem = &init_dati;
   d.elem_from_buf = &from_json;

--- a/discord-public-user.cpp
+++ b/discord-public-user.cpp
@@ -48,6 +48,7 @@ void
 list_from_json(char *str, size_t len, void *p_users)
 {
   struct ntl_deserializer d;
+  memset(&d, 0, sizeof(d));
   d.elem_size = sizeof(dati);
   d.init_elem = &init_dati;
   d.elem_from_buf = &from_json;

--- a/discord-websockets.cpp
+++ b/discord-websockets.cpp
@@ -248,6 +248,7 @@ void
 list_from_json(char *str, size_t len, void *p_activities)
 {
   struct ntl_deserializer d;
+  memset(&d, 0, sizeof(d));
   d.elem_size = sizeof(dati);
   d.init_elem = &init_dati;
   d.elem_from_buf = &from_json;
@@ -747,6 +748,7 @@ custom_cws_new(dati *ws)
 {
   //missing on_binary, on_ping, on_pong
   struct cws_callbacks cws_cbs;
+  memset(&cws_cbs, 0, sizeof(cws_cbs));
   cws_cbs.on_connect = &ws_on_connect_cb;
   cws_cbs.on_text = &ws_on_text_cb;
   cws_cbs.on_close = &ws_on_close_cb;


### PR DESCRIPTION
fix: the regression caused by converting struct initializer to assignment which miss the fields that are not present.