### PR TITLE
fix: include <stdint.h> inside discord-common.h

### DIFF
--- a/discord-common.h
+++ b/discord-common.h
@@ -1,6 +1,7 @@
 #ifndef LIBDISCORD_COMMON_H
 #define LIBDISCORD_COMMON_H
 
+#include <stdint.h>
 #include <curl/curl.h>
 #include "json-scanf.h"
 #include "json-actor.h"


### PR DESCRIPTION
fix: include `<stdint.h>` inside `discord-common.h`
I had a problem compiling the tests, because `uint64_t` wasn't detected.