### PR TITLE
fix: add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dump.*
 .cee-contributor
 specs/*.cc
 specs/*.h
+.vscode


### PR DESCRIPTION
fix: add `.vscode` to `.gitignore`

Note: this will solve a problem for VSC users, when they add a file called `c_cpp_properties.json` inside `.vscode` to add the include paths. If it's inside `.gitignore`, they can easily use `git add .` and `git pull`, without commiting this changes.