### PR TITLE
fix: change specs to specs-code in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ obj
 lib
 dump.*
 .cee-contributor
-specs/*.cc
-specs/*.hh
+specs-code/*.cc
+specs-code/*.hh
 .vscode


### PR DESCRIPTION
fix: change `specs` to `specs-code` in `.gitignore`