### PR TITLE
fix: add .c and .h files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ dump.*
 .cee-contributor
 specs-code/*.cc
 specs-code/*.hh
+specs-code/*.c
+specs-code/*.h
 .vscode


### PR DESCRIPTION
fix: add `.c` and `.h` files to `.gitignore`
Please use `Merge Squash`.