### PR TITLE
n1615945326

### DIFF
--- a/bots/bot-fetch-messages.cpp
+++ b/bots/bot-fetch-messages.cpp
@@ -84,7 +84,7 @@ fetch_member_msgs(client *client, uint64_t guild_id, uint64_t user_id)
   dati **channels = guild::get_channels(client, guild_id);
   ASSERT_S(NULL != channels, "Couldn't fetch channels from guild");
   
-  message::get_list::params params = {
+  channel::get_channel_messages::params params = {
     .limit = 100
   };
 
@@ -95,7 +95,7 @@ fetch_member_msgs(client *client, uint64_t guild_id, uint64_t user_id)
 
     int n_msg;
     do {
-      messages = message::get_list::run(client, channels[i]->id, &params);
+      messages = channel::get_channel_messages::run(client, channels[i]->id, &params);
       ASSERT_S(NULL != messages, "Couldn't fetch messages from channel");
 
       for (n_msg = 0; messages[n_msg]; ++n_msg) {

--- a/discord-public-channel.cpp
+++ b/discord-public-channel.cpp
@@ -145,8 +145,9 @@ dati_from_json(char *str, size_t len, dati *message)
 
   DS_NOTOP_PUTS("Message object loaded with API response"); 
 }
+} // message
 
-namespace get_list {
+namespace get_channel_messages {
 
 message::dati**
 run(client *client, const uint64_t channel_id, params *params)
@@ -186,7 +187,7 @@ run(client *client, const uint64_t channel_id, params *params)
         "&after=%" PRIu64 , params->after);
   }
 
-  dati **new_messages = NULL;
+  message::dati **new_messages = NULL;
 
   struct resp_handle resp_handle = 
     { .ok_cb = &dati_list_from_json_v, .ok_obj = (void*)&new_messages};
@@ -201,9 +202,10 @@ run(client *client, const uint64_t channel_id, params *params)
 
   return new_messages;
 }
+} // namespace get_channel_messages
 
-} // namespace get_list
 
+namespace message {
 namespace create {
 
 //@todo this is a temporary solution

--- a/libdiscord.h
+++ b/libdiscord.h
@@ -53,7 +53,6 @@ enum dispatch_code {
   READY,
   RESUMED,
   MESSAGE_CREATE,
-  SB_MESSAGE_CREATE, //@todo this is temporary for wrapping JS
   MESSAGE_UPDATE,
   MESSAGE_DELETE,
   MESSAGE_DELETE_BULK,
@@ -110,22 +109,19 @@ void pin_message(client *client, const uint64_t channel_id, const uint64_t messa
 void unpin_message(client *client, const uint64_t channel_id, const uint64_t message_id);
 void trigger_typing(client *client, const uint64_t channel_id);
 
-namespace message {
 
 /* https://discord.com/developers/docs/resources/channel#get-channel-messages */
-namespace get_list { // function wrapper
-
+namespace get_channel_messages { // function wrapper
 struct params {
   uint64_t around;
   uint64_t before;
   uint64_t after;
   int limit; // max number of messages (1-100)
 };
-
 message::dati** run(client *client, const uint64_t channel_id, params *params);
+} // namespace get_channel_messages
 
-} // namespace get_list
-
+namespace message {
 /* https://discord.com/developers/docs/resources/channel#create-message */
 namespace create { // function wrapper
 
@@ -277,7 +273,6 @@ void get(client *client, const uint64_t user_id, dati *p_user);
 namespace me { // current user centered functions
 
 void get(client *client, dati *p_user);
-void sb_get(client *client, struct sized_buffer *p_sb_user);
 guild::dati** get_guilds(client *client);
 void leave_guild(client *client, const u64_snowflake_t guild_id);
 


### PR DESCRIPTION
refactor: move message::get_list to gen_channel_messages so it maps to the get channel messages end point's url, this will make searching implemented endpoint easier