### PR TITLE
fix: add pthread.h include inside user-agent.h

### DIFF
--- a/common/user-agent.h
+++ b/common/user-agent.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include <curl/curl.h>
+#include <pthread.h>
 
 #include "ntl.h"
 #include "orka-config.h"


### PR DESCRIPTION
It won't affect Ubuntu build, just fix problems with Windows build.