### PR TITLE
fix: remove linux default folders, because vsc automatically includes

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -7,9 +7,7 @@
                 "common",
                 "mujs",
                 "sqlite3",
-                "${workspaceFolder}/**",
-                "/usr/include",
-                "/usr/local/include"
+                "${workspaceFolder}/**"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",


### PR DESCRIPTION
fix: remove linux default folders, because Visual Studio Code automatically includes them.