### PR TITLE
Allow printf-esque formatting in embed-titles

### DIFF
--- a/bots/bot-embed-formatting.c
+++ b/bots/bot-embed-formatting.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   discord_set_on_ready(client, &on_ready);
   discord_set_on_command(client, "format embed", &on_command);
 
-  printf("\n\nThis bot demonstrates how easy it is to format embed text for embeds.\n"
+  printf("\n\nThis bot demonstrates how easy it is to format the title text for embeds.\n"
          "Type 'format embed' in any channel to trigger the bot\n"
          "\nTYPE ANY KEY TO START BOT\n");
   fgetc(stdin);

--- a/bots/bot-embed-formatting.c
+++ b/bots/bot-embed-formatting.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "discord.h"
+#include "cee-utils.h"
+
+void on_ready(struct discord *client, const struct discord_user *bot) {
+  fprintf(stderr, "\n\nEmbed-Bot succesfully connected to Discord as %s#%s!\n\n",
+      bot->username, bot->discriminator);
+}
+
+void on_command(struct discord *client, const struct discord_user *bot, const struct discord_message *msg)
+{
+  if (msg->author->bot) return;
+
+  struct discord_embed *embed = discord_embed_alloc();
+  discord_embed_set_title(embed, "String: %s Integer: %d Scientific Notation: %E", "Test", 42, 12345678);
+  discord_embed_add_field(embed, "Field", "Value", false);
+
+  struct discord_create_message_params params = {
+    .embed = embed
+  };
+
+  discord_create_message(client, msg->channel_id, &params, NULL);
+  discord_embed_free(embed);
+}
+
+
+int main(int argc, char *argv[])
+{
+  const char *config_file;
+  if (argc > 1)
+    config_file = argv[1];
+  else
+    config_file = "bot.config";
+
+  discord_global_init();
+  struct discord *client = discord_config_init(config_file);
+
+  assert(NULL != client && "Couldn't initialize client");
+
+  discord_set_on_ready(client, &on_ready);
+  discord_set_on_command(client, "format embed", &on_command);
+
+  printf("\n\nThis bot demonstrates how easy it is to format embed text for embeds.\n"
+         "Type 'format embed' in any channel to trigger the bot\n"
+         "\nTYPE ANY KEY TO START BOT\n");
+  fgetc(stdin);
+
+  discord_run(client);
+  discord_cleanup(client);
+  discord_global_cleanup();
+}
+

--- a/discord-misc.c
+++ b/discord-misc.c
@@ -214,6 +214,18 @@ discord_embed_set_footer(
   embed->footer = new_footer;
 }
 
+
+void discord_embed_set_title(
+  struct discord_embed *embed, 
+  char format[], 
+  ...)
+{
+  va_list args;
+  va_start(args, format);
+  vsnprintf(embed->title, sizeof(embed->title), format, args);
+  va_end(args);
+}
+
 void
 discord_embed_set_thumbnail(
   struct discord_embed *embed, 

--- a/discord.h
+++ b/discord.h
@@ -907,6 +907,7 @@ void discord_embed_set_video(struct discord_embed *embed, char url[], char proxy
 void discord_embed_set_footer(struct discord_embed *embed, char text[], char icon_url[], char proxy_icon_url[]);
 void discord_embed_set_provider(struct discord_embed *embed, char name[], char url[]);
 void discord_embed_set_author(struct discord_embed *embed, char name[], char url[], char icon_url[], char proxy_icon_url[]);
+void discord_embed_set_title(struct discord_embed *embed, char format[], ...);
 void discord_embed_add_field(struct discord_embed *embed, char name[], char value[], bool Inline);
 /** @} */
 


### PR DESCRIPTION
This PR allows for setting the title of an embed with additional formatting, e.g.:

`discord_embed_set_title(embed, "String: %s Integer: %d Scientific Notation: %E", "Test", 42, 12345678);`