### PR TITLE
feat: added github_list_public_gists and bot example

### DIFF
--- a/bots/bot-github-public-gists.c
+++ b/bots/bot-github-public-gists.c
@@ -1,0 +1,23 @@
+/*
+ * A bot that lists public gists in JSON form.
+*/
+#include <stdio.h>
+#include "github.h"
+void print_usage()
+{
+    printf("bot-github-public-gists - create gists from the terminal\n");
+    printf("Usage: bot-github-public-gists.exe\n\n");
+}
+int main(int argc, char *argv[])
+{
+    struct github *client = github_config_init("bot.config", NULL);
+    if (argc > 1) {
+        print_usage();
+        exit(1);
+    }
+    struct sized_buffer buffer;
+    struct github_list_public_gists_params params = {.page = 0, .per_page = 30, .since = ""};
+    github_list_public_gists(client, &params, &buffer);
+    printf("%s\n", buffer.start);
+    return 0;
+}

--- a/github-gist.c
+++ b/github-gist.c
@@ -95,3 +95,30 @@ github_gist_is_starred(struct github *client, char *id) {
           HTTP_GET,
           "/gists/%s/star", id);
 }
+
+
+ORCAcode
+github_list_public_gists(struct github *client, struct github_list_public_gists_params *params, struct sized_buffer *output) {
+  log_info("===list-public-gists===");
+
+  if (!output) {
+    log_error("Missing 'output'");
+    return ORCA_MISSING_PARAMETER;
+  }
+
+  if (!params) {
+    log_error("Missing 'params'");
+    return ORCA_MISSING_PARAMETER;
+  }
+
+  return github_adapter_run(
+          &client->adapter,
+          &(struct ua_resp_handle){
+            .ok_cb = github_write_json,
+            .ok_obj = output,
+          },
+          NULL,
+          HTTP_GET,
+          "/gists/public?since=%s&per_page=%i&page=%i",
+          params->since, params->per_page, params->page);
+}

--- a/github.h
+++ b/github.h
@@ -36,9 +36,11 @@ ORCAcode github_create_a_pull_request(struct github *client, char *branch, char 
 ORCAcode github_get_user(struct github *client, char *username, struct github_user* user);
 ORCAcode github_fill_repo_config(struct github *client, char *repo_config);
 ORCAcode github_get_repository(struct github *client, char* owner, char* repo, struct sized_buffer* output);
-
 ORCAcode github_get_gist(struct github *client, char *id, struct github_gist *gist);
 ORCAcode github_create_gist(struct github *client, struct github_gist_create_params *params, struct github_gist *gist);
 ORCAcode github_gist_is_starred(struct github *client, char *id);
+ORCAcode github_list_public_gists(struct github *client, struct github_list_public_gists_params *params, struct sized_buffer *output);
+
+void github_write_json(char* json, size_t len, void *user_obj);
 
 #endif // GITHUB_V3_H


### PR DESCRIPTION
I have added a function to retrieve the JSON of the public gists, on GitHub. I have also implemented features to allow the programmer to use pagination in retrieval of public gists.