### PR TITLE
Modularized logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ make
 The following outlines the default fields of `config.json`
 ```js
 {
-  "logging": {               // logging directives
+  "logging": { // logging directives
     "level": "trace",        // trace, debug, info, warn, error, fatal
     "filename": "bot.log",   // the output file
     "quiet": false,          // change to true to disable logs in console
@@ -125,9 +125,10 @@ The following outlines the default fields of `config.json`
     "http": {
       "enable": true,        // generate http specific logging
       "filename": "http.log" // the output file
-    }
+    },
+    "disable_modules": ["WEBSOCKETS", "USER_AGENT"] // disable logging for these modules
   },
-  ... // API specific directives (discord, slack, github, etc)
+  ...         // API directives (discord, slack, github, etc)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Installed headers must be prefixed with `orca/` like so:
 #include <orca/github.h>
 ```
 
+### Standalone executable
+
+```bash
+$ gcc myBot.c -o myBot.out -ldiscord -lcurl -lcrypto -lpthread -lm
+```
+
 ## Debugging Memory Errors
 
 * The recommended method: 

--- a/common/js_user-agent.c
+++ b/common/js_user-agent.c
@@ -92,7 +92,9 @@ new_UserAgent(js_State *J)
   static _Bool first_run=0;
 
   if (!first_run) {
-    logconf_setup(&config, g_config_file);
+    FILE *fp = fopen(g_config_file, "rb");
+    logconf_setup(&config, "JS_UserAgent", fp);
+    fclose(fp);
     first_run = 1;
   }
 

--- a/common/user-agent.h
+++ b/common/user-agent.h
@@ -140,7 +140,7 @@ char* ua_reqheader_str(struct user_agent *ua, char *buf, size_t bufsize);
 void ua_curl_easy_setopt(struct user_agent *ua, void *data, void (setopt_cb)(CURL *ehandle, void *data));
 void ua_curl_mime_setopt(struct user_agent *ua, void *data, curl_mime* (mime_cb)(CURL *ehandle, void *data)); // @todo this is temporary
 
-struct user_agent* ua_init(struct logconf *conf);
+struct user_agent* ua_init(struct logconf *config);
 struct user_agent* ua_clone(struct user_agent *orig_ua);
 void ua_cleanup(struct user_agent *ua);
 

--- a/common/websockets.h
+++ b/common/websockets.h
@@ -116,7 +116,7 @@ struct ws_callbacks {
  * @brief Create a new (CURL-based) WebSockets handle
  *
  * @param cbs set of functions to call back when server report events.
- * @param config optional pointer to a pre-initialized logconf 
+ * @param config optional parent logconf struct
  * @return newly created WebSockets handle, free with ws_cleanup()
  */
 struct websockets* ws_init(struct ws_callbacks *cbs, struct logconf *config);

--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
     "http": {
       "enable": true,
       "filename": "http.log"
-    }
+    },
+    "disable_modules": ["WEBSOCKETS", "USER_AGENT"]
   },
   "discord": {
     "token": "YOUR-BOT-TOKEN",

--- a/discord-internal.h
+++ b/discord-internal.h
@@ -34,6 +34,7 @@
  */
 struct discord_adapter {
   struct user_agent *ua; ///< The user agent handle for performing requests
+  struct logconf conf; ///< store conf file contents and sync logging between clients
 
   struct { ///< Ratelimiting structure
     struct discord_bucket *buckets; ///< Endpoint/routes discovered, check a endpoint/bucket match with tree search functions
@@ -51,10 +52,10 @@ struct discord_adapter {
  * @brief Initialize the fields of a Discord Adapter handle
  *
  * @param adapter a pointer to the allocated handle
- * @param config optional pointer to a pre-initialized logconf
+ * @param conf optional pointer to a pre-initialized logconf
  * @param token the bot token
  */
-void discord_adapter_init(struct discord_adapter *adapter, struct logconf *config, struct sized_buffer *token);
+void discord_adapter_init(struct discord_adapter *adapter, struct logconf *conf, struct sized_buffer *token);
 
 /**
  * @brief Free a Discord Adapter handle
@@ -208,6 +209,7 @@ struct discord_gateway_cbs {
  */
 struct discord_gateway {
   struct websockets *ws; ///< the websockets handle that connects to Discord
+  struct logconf conf; ///< store conf file contents and sync logging between clients
 
   struct { ///< Reconnect structure
     bool enable; ///< will attempt reconnecting if true
@@ -267,10 +269,10 @@ struct discord_gateway {
  * @brief Initialize the fields of Discord Gateway handle
  *
  * @param gw a pointer to the allocated handle
- * @param config optional pointer to a initialized logconf
+ * @param conf optional pointer to a initialized logconf
  * @param token the bot token
  */
-void discord_gateway_init(struct discord_gateway *gw, struct logconf *config, struct sized_buffer *token);
+void discord_gateway_init(struct discord_gateway *gw, struct logconf *conf, struct sized_buffer *token);
 
 /**
  * @brief Free a Discord Gateway handle
@@ -310,7 +312,7 @@ void discord_gateway_reconnect(struct discord_gateway *gw, bool resume);
  * Used to access/perform public functions from discord.h 
  *
  * - Initializer:
- *   - discord_init(), discord_config_init()
+ *   - discord_init(), discord_conf_init()
  * - Cleanup:
  *   - discord_cleanup()
  *
@@ -321,8 +323,9 @@ struct discord {
   /// @privatesection
   bool is_original; ///< whether this is the original client or a clone
 
+  struct logconf *conf; ///< store conf file contents and sync logging between clients
+
   struct sized_buffer token;   ///< the bot token
-  struct logconf      *config; ///< store config file contents and sync logging between clients
 
   struct discord_adapter adapter; ///< the HTTP adapter for performing requests
   struct discord_gateway gw;      ///< the WebSockets handle for establishing a connection to Discord

--- a/discord-voice-connections.c
+++ b/discord-voice-connections.c
@@ -359,7 +359,7 @@ _discord_voice_init(
       .on_text = &on_text_cb,
       .on_close = &on_close_cb
     };
-    new_vc->ws = ws_init(&cbs, new_vc->p_client->config);
+    new_vc->ws = ws_init(&cbs, new_vc->p_client->conf);
     new_vc->reconnect.threshold = 5; /** hard limit for now */
     new_vc->reconnect.enable = true;
   }
@@ -405,9 +405,11 @@ recycle_active_vc(
   vc->guild_id = guild_id;
   vc->shutdown = false;
 
+#if 0
   char tag[64];
   snprintf(tag, sizeof tag, "VC_%"PRIu64, guild_id);
-  logconf_add_id(vc->p_client->config, vc->ws, tag);
+  logconf_branch(&vc->config, vc->p_client->config, tag);
+#endif
 }
 
 static void

--- a/docs/BUILDING_A_BOT.md
+++ b/docs/BUILDING_A_BOT.md
@@ -138,18 +138,10 @@ discord_cleanup(client);
 
 ## Compile the bot
 
-### Using the preset Makefile
-
 ```bash
 $ make
 ```
 *Note: The preset Makefile will separately compile each file from the `my_bot` folder that has a `.c` extension.* 
-
-### As a standalone executable
-
-```bash
-$ gcc myBot.c -o myBot.out -ldiscord -lcurl -lcrypto -lpthread -lm
-```
 
 ## Execute the bot
 

--- a/examples/bot-elitebgs.c
+++ b/examples/bot-elitebgs.c
@@ -319,9 +319,8 @@ int main(int argc, char *argv[])
   assert(NULL != client);
 
   /* Initialize ELITEBGS User Agent (share discord logconf) */
-  g_elitebgs_ua = ua_init(client->config);
+  g_elitebgs_ua = ua_init(client->conf);
   ua_set_url(g_elitebgs_ua, ELITEBGS_API_URL);
-  logconf_add_id(client->config, g_elitebgs_ua, "ELITEBGS_HTTP");
 
   /* Set discord callbacks */
   discord_set_on_ready(client, &on_ready);

--- a/github-adapter.c
+++ b/github-adapter.c
@@ -25,9 +25,9 @@ curl_easy_setopt_cb(CURL *ehandle, void *data)
 }
 
 void
-github_adapter_init(struct github_adapter *adapter, struct logconf *config, struct github_presets *presets)
+github_adapter_init(struct github_adapter *adapter, struct logconf *conf, struct github_presets *presets)
 {
-  adapter->ua = ua_init(config);
+  adapter->ua = ua_init(conf);
   ua_set_url(adapter->ua, GITHUB_BASE_API_URL);
   ua_reqheader_add(adapter->ua, "Accept", "application/vnd.github.v3+json");
   ua_curl_easy_setopt(adapter->ua, presets, &curl_easy_setopt_cb);

--- a/github-internal.h
+++ b/github-internal.h
@@ -16,7 +16,7 @@ struct github_adapter {
   struct user_agent *ua;
 };
 
-void github_adapter_init(struct github_adapter *adapter, struct logconf *config, struct github_presets *presets);
+void github_adapter_init(struct github_adapter *adapter, struct logconf *conf, struct github_presets *presets);
 
 ORCAcode github_adapter_run(
   struct github_adapter *adapter,
@@ -26,7 +26,7 @@ ORCAcode github_adapter_run(
   char endpoint[], ...);
 
 struct github {
-  struct logconf config;
+  struct logconf conf;
   struct github_adapter adapter;
   struct github_presets presets;
 };

--- a/reddit-adapter.c
+++ b/reddit-adapter.c
@@ -29,11 +29,11 @@ curl_setopt_cb(CURL *ehandle, void *p_client)
 }
 
 void
-reddit_adapter_init(struct reddit_adapter *adapter, struct logconf *config)
+reddit_adapter_init(struct reddit_adapter *adapter, struct logconf *conf)
 {
-  adapter->ua = ua_init(config);
+  adapter->ua = ua_init(conf);
   ua_set_url(adapter->ua, BASE_API_URL);
-  logconf_add_id(config, adapter->ua, "REDDIT_HTTP");
+  logconf_branch(&adapter->conf, conf, "REDDIT_HTTP");
 
   ua_curl_easy_setopt(adapter->ua, adapter->p_client, &curl_setopt_cb);
 

--- a/reddit-client.c
+++ b/reddit-client.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <errno.h>
 
 #include "reddit.h"
 #include "reddit-internal.h"
@@ -7,7 +8,7 @@ static void
 _reddit_init(struct reddit *new_client)
 {
   new_client->adapter.p_client = new_client;
-  reddit_adapter_init(&new_client->adapter, &new_client->config);
+  reddit_adapter_init(&new_client->adapter, &new_client->conf);
 }
 
 
@@ -20,7 +21,7 @@ reddit_init(
 {
   struct reddit *new_client = calloc(1, sizeof *new_client);
 
-  logconf_setup(&new_client->config, NULL);
+  logconf_setup(&new_client->conf, "REDDIT", NULL);
 
   *new_client = (struct reddit){
     .username = {
@@ -51,12 +52,17 @@ reddit_config_init(const char config_file[])
 {
   struct reddit *new_client = calloc(1, sizeof *new_client);
 
-  logconf_setup(&new_client->config, config_file);
+  FILE *fp = fopen(config_file, "rb");
+  VASSERT_S(fp != NULL, "Couldn't open '%s': %s", config_file, strerror(errno));
 
-  new_client->username = logconf_get_field(&new_client->config, "reddit.username");
-  new_client->password = logconf_get_field(&new_client->config, "reddit.password");
-  new_client->client_id = logconf_get_field(&new_client->config, "reddit.client_id");
-  new_client->client_secret = logconf_get_field(&new_client->config, "reddit.client_secret");
+  logconf_setup(&new_client->conf, "REDDIT", fp);
+
+  fclose(fp);
+
+  new_client->username = logconf_get_field(&new_client->conf, "reddit.username");
+  new_client->password = logconf_get_field(&new_client->conf, "reddit.password");
+  new_client->client_id = logconf_get_field(&new_client->conf, "reddit.client_id");
+  new_client->client_secret = logconf_get_field(&new_client->conf, "reddit.client_secret");
 
   _reddit_init(new_client);
 
@@ -66,7 +72,7 @@ reddit_config_init(const char config_file[])
 void 
 reddit_cleanup(struct reddit *client)
 {
-  logconf_cleanup(&client->config);
+  logconf_cleanup(&client->conf);
   reddit_adapter_cleanup(&client->adapter);
   free(client);
 }

--- a/reddit-internal.h
+++ b/reddit-internal.h
@@ -15,11 +15,12 @@
 
 struct reddit_adapter {
   struct user_agent *ua;
+  struct logconf conf;
   struct reddit *p_client;
 };
 
 /* ADAPTER PRIVATE FUNCTIONS */
-void reddit_adapter_init(struct reddit_adapter *adapter, struct logconf *config);
+void reddit_adapter_init(struct reddit_adapter *adapter, struct logconf *conf);
 void reddit_adapter_cleanup(struct reddit_adapter *adapter);
 
 ORCAcode reddit_adapter_run(
@@ -35,7 +36,7 @@ struct reddit {
   struct sized_buffer client_secret;
 
   struct reddit_adapter adapter;
-  struct logconf config;
+  struct logconf conf;
 };
 
 #endif // REDDIT_INTERNAL_H

--- a/slack-client.c
+++ b/slack-client.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <errno.h>
 
 #include "slack.h"
 #include "slack-internal.h"
@@ -9,14 +10,20 @@ slack_config_init(const char config_file[])
 {
   struct slack *new_client = calloc(1, sizeof *new_client);
 
-  logconf_setup(&new_client->config, config_file);
-  new_client->bot_token = logconf_get_field(&new_client->config, "slack.bot_token");
-  new_client->app_token = logconf_get_field(&new_client->config, "slack.app_token");
+  FILE *fp = fopen(config_file, "rb");
+  VASSERT_S(fp != NULL, "Couldn't open '%s': %s", config_file, strerror(errno));
+
+  logconf_setup(&new_client->conf, "SLACK", fp);
+
+  fclose(fp);
+
+  new_client->bot_token = logconf_get_field(&new_client->conf, "slack.bot_token");
+  new_client->app_token = logconf_get_field(&new_client->conf, "slack.app_token");
 
   new_client->webapi.p_client = new_client;
   new_client->sm.p_client = new_client;
-  slack_webapi_init(&new_client->webapi, &new_client->config, &new_client->bot_token);
-  slack_sm_init(&new_client->sm, &new_client->config);
+  slack_webapi_init(&new_client->webapi, &new_client->conf, &new_client->bot_token);
+  slack_sm_init(&new_client->sm, &new_client->conf);
 
   return new_client;
 }
@@ -24,7 +31,7 @@ slack_config_init(const char config_file[])
 void 
 slack_cleanup(struct slack *client)
 {
-  logconf_cleanup(&client->config);
+  logconf_cleanup(&client->conf);
   slack_webapi_cleanup(&client->webapi);
   slack_sm_cleanup(&client->sm);
 

--- a/slack-internal.h
+++ b/slack-internal.h
@@ -13,11 +13,13 @@
 
 struct slack_webapi {
   struct user_agent *ua;
+  struct logconf conf;
+
   struct slack *p_client;
 };
 
 /* ADAPTER PRIVATE FUNCTIONS */
-void slack_webapi_init(struct slack_webapi *webapi, struct logconf *config, struct sized_buffer *token);
+void slack_webapi_init(struct slack_webapi *webapi, struct logconf *conf, struct sized_buffer *token);
 void slack_webapi_cleanup(struct slack_webapi *webapi);
 
 ORCAcode slack_webapi_run(
@@ -28,6 +30,8 @@ ORCAcode slack_webapi_run(
 
 struct slack_sm {
   struct websockets *ws;
+  struct logconf conf;
+
   bool is_ready;
 
   struct { /* SOCKETMODE HEARTBEAT STRUCT */
@@ -53,7 +57,7 @@ struct slack_sm {
 };
 
 /* SOCKET MODE PRIVATE FUNCTIONS */
-void slack_sm_init(struct slack_sm *sm, struct logconf *config);
+void slack_sm_init(struct slack_sm *sm, struct logconf *conf);
 void slack_sm_cleanup(struct slack_sm *sm);
 
 struct slack {
@@ -63,7 +67,7 @@ struct slack {
   struct slack_webapi webapi;
   struct slack_sm sm;
 
-  struct logconf config;
+  struct logconf conf;
 };
 
 struct slack_event_cxt {

--- a/slack-socketmode.c
+++ b/slack-socketmode.c
@@ -261,7 +261,7 @@ refresh_connection(struct slack_sm *sm)
 }
 
 void
-slack_sm_init(struct slack_sm *sm, struct logconf *config)
+slack_sm_init(struct slack_sm *sm, struct logconf *conf)
 {
   ASSERT_S(NULL != sm->p_client, "Not meant to be called standalone");
 
@@ -271,8 +271,8 @@ slack_sm_init(struct slack_sm *sm, struct logconf *config)
     .on_text = &on_text_cb,
     .on_close = &on_close_cb
   };
-  sm->ws = ws_init(&cbs, config);
-  logconf_add_id(config, sm->ws, "SLACK_SOCKETMODE");
+  sm->ws = ws_init(&cbs, conf);
+  logconf_branch(&sm->conf, conf, "SLACK_SOCKETMODE");
 
   sm->event_handler = &noop_event_handler;
 

--- a/slack-webapi.c
+++ b/slack-webapi.c
@@ -12,11 +12,11 @@
 
 
 void
-slack_webapi_init(struct slack_webapi *webapi, struct logconf *config, struct sized_buffer *token)
+slack_webapi_init(struct slack_webapi *webapi, struct logconf *conf, struct sized_buffer *token)
 {
-  webapi->ua = ua_init(config);
+  webapi->ua = ua_init(conf);
   ua_set_url(webapi->ua, SLACK_BASE_API_URL);
-  logconf_add_id(config, webapi->ua, "SLACK_WEBAPI");
+  logconf_branch(&webapi->conf, conf, "SLACK_WEBAPI");
 
   if (STRNEQ("YOUR-BOT-TOKEN", token->start, token->size)) {
     token->start = NULL;

--- a/test/test-cee.c
+++ b/test/test-cee.c
@@ -12,7 +12,6 @@ int commit(char *base_url, struct logconf *config)
 {
   struct user_agent *data = ua_init(config);
   ua_set_url(data, base_url);
-  logconf_add_id(config, data, "CEE_HTTP");
 
   curl_global_init(CURL_GLOBAL_ALL);
   struct sized_buffer body = {.start = "{ }", .size = 3};
@@ -38,8 +37,10 @@ int main(int argc, char *argv[])
   else
     config_file = "../config.json";
 
-  struct logconf config={0};
-  logconf_setup(&config, config_file);
+  struct logconf config;
+  FILE *fp = fopen(config_file, "rb");
+  logconf_setup(&config, "CEE_HTTP", fp);
+  fclose(fp);
 
   commit("https://cee.studio", &config);
 

--- a/test/test-js-bindings.c
+++ b/test/test-js-bindings.c
@@ -12,7 +12,7 @@ const char *g_config_file;
 void js_request(js_State *J)
 {
   struct logconf config={0};
-  logconf_setup(&config, NULL);
+  logconf_setup(&config, "JS_TEST", NULL);
 
   struct user_agent *ua = ua_init(&config);
   ua_set_url(ua, "http://www.example.com/");


### PR DESCRIPTION
Closes #694. This PR introduces the ability of toggling particular logging sections (aka modules). If you wanted to disable `user-agent` and `websockets` logging it wouldn't be possible before because all logging would share the same global variable. This also means the user wouldn't be able to use any of the [log.c](https://github.com/rxi/log.c) functions without it interfering with Orca's internal logging. This PR makes it possible to start individual modules via `logconf_setup()`, and also to branch it to submodules by calling `logconf_branch()`, the latter ensures that the same file-descriptor (and some other resources) will be shared by the modules of the same family.