### PR TITLE
Proofread of Internals Guide

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1,61 +1,57 @@
 # orca-internals.md
-This is a guide on how Orca works internally. Orca is a collection of
-REST API wrappers that is written in C. While Orca is not insanely complex,
-it is still a fairly large project. This guide aims to introduce new users
-who may be interested in contributing to Orca with more information than
-simply coding guidelines. The intention behind this is to guide the user
-through implementing their own API endpoint.
-
-Through reading this guide, if you have any questions, feel free to join the
-Discord server for Orca, [SaiphCee](https://discord.gg/evbfgCUtSW).
+If you are interested in contributing to Orca with more in mind than just 
+coding, you found the right place! The ultimate goal is to help you understand 
+how Orca works internally, and as a result, write your own API endpoint.
 
 # Introduction
-There are many APIs out there. Orca currently only covers the Discord API,
-and some of the GitHub API, but there are already-existing projects in Orca
-for Reddit and the Slack API.
+Orca is a collection of REST API wrappers that are written in C. Orca currently 
+covers the Discord, GitHub, Reddit, and the Slack API. While this guide will only
+use one of those APIs, it is worth noting the existence of the other source files.
 
-For the purposes of this guide, we will choose to write an endpoint for the
-GitHub API. To get started, make sure you have installed Orca using the
-installation instructions for your platform of choice [here](https://github.com/cee-studio/orca).
+This guide will cover writing an endpoint for the GitHub API. To get started, 
+make sure you have installed Orca using the installation instructions for your 
+platform of choice [here](https://github.com/cee-studio/orca).
 
-# A tour of Orca
-Orca is a fairly large project. Because of this, it may be confusing to new
-potential contributors where to look for certain things. In this guide I will
-go over each of the major folders and files that will be used for.
+# A Tour of Orca
+While Orca is not complex, it is still a decent sized project. Searching the 
+documentation may be confusing to new potential contributors when looking for 
+certain things. This part of the guide will cover each of the major folders and 
+the files they contain.
 
 ## Orca specs
-These two folders and their contents are some of the most important parts of
-Orca's internal workings. These two folders, or 'the specs' as you may hear
-them be called, are a method of code generation.
+``specs`` and ``specs-code`` and their contents are important parts of Orca's
+internal workings. These two folders, also denoted as "the specs," are a method 
+of code generation.
 
-``specs`` is the folder where many 'templates' are stored for structures,
+``specs`` is the folder where many "templates" are stored for structures,
 enumerations, and more. They are written in JSON and are used to generate their
 C code equivalents. This system is better than writing the structures and
 enumerations in a header file because it allows for the generation of functions
 to convert JSON objects to actual structures.
 
 ## Examples
-This folder is where all the examples of bots are stored. It will be useful if
-you are a regular user of Orca, but it might also give you a demonstration of
-how to write code that is in-line with Orca's existing code base.
+The ``examples`` folder is where all the examples of bots are stored. It will 
+provide a demonstration of how to write code that is in-line with Orca's existing
+code base.
 
 When you finish adding an endpoint, it is encouraged to write a bot that uses
 the endpoint inside of this folder as a sort of makeshift test for other users
 or developers.
 
 ## discord*.c, github*.c, reddit*.c, and slack*.c
-These are the source files that handle all the actual logic behind their individual
-API wrapper. For the purposes of this guide, we will only be using the GitHub
-source files, however it is worth noting the existence of the other source files.
+`discord*.c`, `github*.c`, `reddit*.c`, and `slack*.c` are the source 
+files that handle all the logic behind their individual API wrapper.
 
-# Choosing an endpoint
+# Choosing an Endpoint
 Now that all the boring reading stuff is out of the way, we can get to the fun
-stuff, implementing an endpoint. First things first, we have to choose an endpoint
+stuff: implementing an endpoint. First things first, we have to choose an endpoint
 to implement. If you are following this guide and do not plan to implement a
-GitHub API endpoint, I will try to keep it as website-independent as possible to
-cover the most use cases.
+GitHub API endpoint, don't fret, this guide aims to remain as website-independent 
+as possible.
 
-To find an endpoint to implement, head over to your website of choice's API
+To find an endpoint to implement, head over to your chosen website's API 
 documentation. This will at least require a simple Google search, but it may
-require a bit of digging to find in some occasions. For our use case, we can use
-the GitHub API reference found [here](https://docs.github.com/en/rest/reference).
+require a bit of digging in some occasions. For this guide, we can use the 
+GitHub API reference found [here](https://docs.github.com/en/rest/reference).
+
+If you have any questions, feel free to join the Discord server for Orca, [SaiphCee](https://discord.gg/evbfgCUtSW).


### PR DESCRIPTION
Some sentences were moved into other sections. So it goes more like:

Prelog: Goals of the Guide. The prelog was reworded.
Introduction: Introducing Orca (the content was originally there) and how the guide will work
Just wording tweaks in Orca Specs and Examples, nothing big.
discord*.c, github*.c, reddit*.c, and slack*.c text simply identifies what they are
Choosing an endpoint only got some minor wording tweaks.
I dropped the questions reference to the bottom.
Some suggestions for future content would be:
- Try to refrain from using "I" to the best of your ability. Remember: there's always a different way of wording something! Using "you" should be fine as it fits the context of the guide.
- Prepositional phrases such as "Because of this," or "it may be useful if you are a regular user of Orca," tend to be distracting from the point. Avoid them at all costs unless it contributes to the sentence. However, two or three word phrases are totally fine.
- Note: If you can take the phrase out and say it's a sentence of its own, it's probably too long.
- There were repeats of "Orca is a fairly large project," or stated intention of what the section was going to be about being scattered across the guide. I was thinking of keeping everything you plan to cover a dedicated section for easier navigation. Although I didn't include it, it's really up to preference.
Hope this helps!