### PR TITLE
WebSockets synchronization and Discord ratelimiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,13 @@ Orca's implementation has minimum external dependencies to make bot deployment d
 #include <string.h> // strcmp()
 #include <orca/discord.h>
 
-void on_ready(
-  struct discord *client, 
-  const struct discord_user *bot) 
+void on_ready(struct discord *client, const struct discord_user *bot) 
 {
   log_info("Logged in as %s!", bot->username);
 }
 
-void on_message(
-  struct discord *client, 
-  const struct discord_user *bot, 
-  const struct discord_message *msg)
+void on_message(struct discord *client, const struct discord_user *bot, 
+                const struct discord_message *msg)
 {
   // if message content is equal to 'ping', then the bot will respond with 'pong'.
   if (0 == strcmp(msg->content, "ping")) {
@@ -59,7 +55,8 @@ void on_message(
   }
 }
 
-int main() {
+int main(void)
+{
   struct discord *client = discord_init(BOT_TOKEN);
   discord_set_on_ready(client, &on_ready);
   discord_set_on_message_create(client, &on_message);

--- a/common/third-party/curl-websocket.c
+++ b/common/third-party/curl-websocket.c
@@ -179,7 +179,7 @@ struct cws_data {
     bool connection_websocket;
     bool closed;
     bool deleted;
-    clock_t start;
+    time_t start;
 };
 
 static bool
@@ -377,8 +377,9 @@ cws_close(CURL *easy, enum cws_close_reason reason, const char *reason_text, siz
     }
     priv = (struct cws_data *)p;
 
-    long runtime_sec = ((long)(clock() - priv->start)) / CLOCKS_PER_SEC;
-    curl_easy_setopt(easy, CURLOPT_TIMEOUT, runtime_sec + 15L); /* give 15 seconds to terminate connection @todo configurable */
+    /* give 15 seconds to terminate connection @todo configurable */
+    long runtime_sec = (long)(time(NULL) - priv->start);
+    curl_easy_setopt(easy, CURLOPT_TIMEOUT, (long)(runtime_sec + 15L));
 
     if (reason == 0) {
         ret = _cws_send(priv, CWS_OPCODE_CLOSE, NULL, 0);
@@ -498,7 +499,7 @@ _cws_receive_header(const char *buffer, size_t count, size_t nitems, void *data)
             }
             return 0;
         } else {
-            priv->start = clock();
+            priv->start = time(NULL);
             if (priv->cbs.on_connect) {
                 priv->dispatching++;
                 priv->cbs.on_connect((void *)priv->cbs.data,

--- a/common/user-agent.c
+++ b/common/user-agent.c
@@ -528,11 +528,8 @@ ua_set_url(struct user_agent *ua, const char *base_url) {
 
 /* set specific http method used for the request */
 static void
-set_method(
-  struct user_agent *ua,
-  struct _ua_conn *conn, 
-  enum http_method method, 
-  struct sized_buffer *req_body)
+set_method(struct user_agent *ua, struct _ua_conn *conn,
+           enum http_method method, struct sized_buffer *req_body)
 {
   /* resets any preexisting CUSTOMREQUEST */
   curl_easy_setopt(conn->ehandle, CURLOPT_CUSTOMREQUEST, NULL);
@@ -612,12 +609,9 @@ send_request(struct user_agent *ua, struct _ua_conn *conn, int *httpcode)
   /* get response's url */
   curl_easy_getinfo(conn->ehandle, CURLINFO_EFFECTIVE_URL, &resp_url);
 
-  logconf_http(
-    &ua->conf, 
-    &conn->info.loginfo,
-    resp_url, 
-    (struct sized_buffer){conn->info.header.buf, conn->info.header.len},
-    (struct sized_buffer){conn->info.body.buf, conn->info.body.len},
+  logconf_http(&ua->conf, &conn->info.loginfo, resp_url, 
+    (struct sized_buffer){ conn->info.header.buf, conn->info.header.len },
+    (struct sized_buffer){ conn->info.body.buf, conn->info.body.len },
     "HTTP_RCV_%s(%d)", http_code_print(*httpcode), *httpcode);
   pthread_mutex_unlock(&ua->shared->lock);
 
@@ -625,10 +619,8 @@ send_request(struct user_agent *ua, struct _ua_conn *conn, int *httpcode)
 }
 
 static ORCAcode
-perform_request(
-  struct user_agent *ua,
-  struct _ua_conn *conn, 
-  struct ua_resp_handle *resp_handle)
+perform_request(struct user_agent *ua, struct _ua_conn *conn, 
+                struct ua_resp_handle *resp_handle)
 {
   CURLcode ecode = send_request(ua, conn, &conn->info.httpcode);
   if (ecode != CURLE_OK) {
@@ -639,90 +631,65 @@ perform_request(
   /* triggers response related callbacks */
   if (conn->info.httpcode >= 500 && conn->info.httpcode < 600) {
     logconf_error(conn->conf, ANSICOLOR("SERVER ERROR", ANSI_FG_RED)" (%d)%s - %s [@@@_%zu_@@@]",
-        conn->info.httpcode,
-        http_code_print(conn->info.httpcode),
-        http_reason_print(conn->info.httpcode),
-        conn->info.loginfo.counter);
+        conn->info.httpcode, http_code_print(conn->info.httpcode),
+        http_reason_print(conn->info.httpcode), conn->info.loginfo.counter);
 
     if (resp_handle) {
       if (resp_handle->err_cb) {
-        (*resp_handle->err_cb)(
-          conn->info.body.buf,
-          conn->info.body.len,
+        (*resp_handle->err_cb)(conn->info.body.buf, conn->info.body.len,
           resp_handle->err_obj);
       }
       else if (resp_handle->cxt_err_cb) {
-        (*resp_handle->cxt_err_cb)(
-          resp_handle->cxt,
-          conn->info.body.buf,
-          conn->info.body.len,
-          resp_handle->err_obj);
+        (*resp_handle->cxt_err_cb)(resp_handle->cxt, conn->info.body.buf,
+          conn->info.body.len, resp_handle->err_obj);
       }
     }
     return ORCA_HTTP_CODE;
   }
   if (conn->info.httpcode >= 400) {
     logconf_error(conn->conf, ANSICOLOR("CLIENT ERROR", ANSI_FG_RED)" (%d)%s - %s [@@@_%zu_@@@]",
-        conn->info.httpcode,
-        http_code_print(conn->info.httpcode),
-        http_reason_print(conn->info.httpcode),
-        conn->info.loginfo.counter);
+        conn->info.httpcode, http_code_print(conn->info.httpcode),
+        http_reason_print(conn->info.httpcode), conn->info.loginfo.counter);
 
     if (resp_handle) {
       if(resp_handle->err_cb) {
-        (*resp_handle->err_cb)(
-          conn->info.body.buf,
-          conn->info.body.len,
+        (*resp_handle->err_cb)(conn->info.body.buf, conn->info.body.len,
           resp_handle->err_obj);
       }
       else if (resp_handle->cxt_err_cb) {
-        (*resp_handle->cxt_err_cb)(
-          resp_handle->cxt,
-          conn->info.body.buf,
-          conn->info.body.len,
-          resp_handle->err_obj);
+        (*resp_handle->cxt_err_cb)(resp_handle->cxt, conn->info.body.buf,
+          conn->info.body.len, resp_handle->err_obj);
       }
     }
     return ORCA_HTTP_CODE;
   }
   if (conn->info.httpcode >= 300) {
     logconf_warn(conn->conf, ANSICOLOR("REDIRECTING", ANSI_FG_YELLOW)" (%d)%s - %s [@@@_%zu_@@@]",
-        conn->info.httpcode,
-        http_code_print(conn->info.httpcode),
-        http_reason_print(conn->info.httpcode),
-        conn->info.loginfo.counter);
+        conn->info.httpcode, http_code_print(conn->info.httpcode),
+        http_reason_print(conn->info.httpcode), conn->info.loginfo.counter);
     return ORCA_HTTP_CODE;
   }
   if (conn->info.httpcode >= 200) {
     logconf_info(conn->conf, ANSICOLOR("SUCCESS", ANSI_FG_GREEN)" (%d)%s - %s [@@@_%zu_@@@]",
-        conn->info.httpcode,
-        http_code_print(conn->info.httpcode),
-        http_reason_print(conn->info.httpcode),
-        conn->info.loginfo.counter);
+        conn->info.httpcode, http_code_print(conn->info.httpcode),
+        http_reason_print(conn->info.httpcode), conn->info.loginfo.counter);
 
     if (resp_handle) {
       if (resp_handle->ok_cb) {
-        (*resp_handle->ok_cb)(
-          conn->info.body.buf,
-          conn->info.body.len,
-          resp_handle->ok_obj);
+        (*resp_handle->ok_cb)(conn->info.body.buf, conn->info.body.len,
+                              resp_handle->ok_obj);
       }
       else if (resp_handle->cxt_ok_cb) {
-        (*resp_handle->cxt_ok_cb)(
-          resp_handle->cxt,
-          conn->info.body.buf,
-          conn->info.body.len,
-          resp_handle->ok_obj);
+        (*resp_handle->cxt_ok_cb)(resp_handle->cxt, conn->info.body.buf,
+                                  conn->info.body.len, resp_handle->ok_obj);
       }
     }
     return ORCA_OK;
   }
   if (conn->info.httpcode >= 100) {
     logconf_info(conn->conf, ANSICOLOR("INFO", ANSI_FG_GRAY)" (%d)%s - %s [@@@_%zu_@@@]",
-        conn->info.httpcode,
-        http_code_print(conn->info.httpcode),
-        http_reason_print(conn->info.httpcode),
-        conn->info.loginfo.counter);
+        conn->info.httpcode, http_code_print(conn->info.httpcode),
+        http_reason_print(conn->info.httpcode), conn->info.loginfo.counter);
     return conn->info.httpcode;
   }
   if (!conn->info.httpcode) {
@@ -744,12 +711,9 @@ ua_block_ms(struct user_agent *ua, const uint64_t wait_ms)
 
 /* template function for performing requests */
 ORCAcode
-ua_run(
-  struct user_agent *ua,
-  struct ua_info *info,
-  struct ua_resp_handle *resp_handle,
-  struct sized_buffer *req_body,
-  enum http_method http_method, char endpoint[])
+ua_run(struct user_agent *ua, struct ua_info *info,
+       struct ua_resp_handle *resp_handle, struct sized_buffer *req_body,
+       enum http_method http_method, char endpoint[])
 {
   const char *method_str = http_method_print(http_method);
   static struct sized_buffer blank_req_body = {"", 0};
@@ -763,13 +727,8 @@ ua_run(
   char buf[1024]="";
   ua_reqheader_str(ua, buf, sizeof(buf));
 
-  logconf_http(
-    &ua->conf, 
-    &conn->info.loginfo,
-    conn->info.req_url.start, 
-    (struct sized_buffer){buf, sizeof(buf)},
-    *req_body,
-    "HTTP_SEND_%s", method_str);
+  logconf_http(&ua->conf, &conn->info.loginfo, conn->info.req_url.start, 
+    (struct sized_buffer){ buf, sizeof(buf) }, *req_body, "HTTP_SEND_%s", method_str);
 
   logconf_trace(conn->conf, ANSICOLOR("SEND", ANSI_FG_GREEN)" %s [@@@_%zu_@@@]", 
       method_str, conn->info.loginfo.counter);

--- a/common/user-agent.c
+++ b/common/user-agent.c
@@ -618,7 +618,7 @@ send_request(struct user_agent *ua, struct _ua_conn *conn, int *httpcode)
     resp_url, 
     (struct sized_buffer){conn->info.header.buf, conn->info.header.len},
     (struct sized_buffer){conn->info.body.buf, conn->info.body.len},
-    "HTTP_RCV_%s(%d)", http_code_print(*httpcode), httpcode);
+    "HTTP_RCV_%s(%d)", http_code_print(*httpcode), *httpcode);
   pthread_mutex_unlock(&ua->shared->lock);
 
   return ecode;

--- a/common/user-agent.h
+++ b/common/user-agent.h
@@ -113,12 +113,10 @@ void ua_cleanup(struct user_agent *ua);
 void ua_set_url(struct user_agent *ua, const char *base_url);
 const char* ua_get_url(struct user_agent *ua);
 void ua_block_ms(struct user_agent *ua, const uint64_t wait_ms);
-ORCAcode ua_run(
-  struct user_agent *ua,
-  struct ua_info *info,
-  struct ua_resp_handle *resp_handle,
-  struct sized_buffer *req_body,
-  enum http_method http_method, char endpoint[]);
+
+ORCAcode ua_run(struct user_agent *ua, struct ua_info *info,
+                struct ua_resp_handle *resp_handle, struct sized_buffer *req_body,
+                enum http_method http_method, char endpoint[]);
 
 void ua_info_cleanup(struct ua_info *info);
 struct sized_buffer ua_info_header_get(struct ua_info *info, char field[]);

--- a/docs/BUILDING_A_BOT.md
+++ b/docs/BUILDING_A_BOT.md
@@ -26,18 +26,14 @@ The entire code of ping-pong bot is below. We will go over it in further down:
 #include "discord.h"
 
 
-void on_ready(
-  struct discord *client, 
-  const struct discord_user *bot) 
+void on_ready(struct discord *client, const struct discord_user *bot)
 {
   log_info("PingPong-Bot succesfully connected to Discord as %s#%s!",
       bot->username, bot->discriminator);
 }
 
-void on_ping(
-  struct discord *client,
-  const struct discord_user *bot,
-  const struct discord_message *msg)
+void on_ping(struct discord *client, const struct discord_user *bot,
+             const struct discord_message *msg)
 {
   if (msg->author->bot) return; // ignore bots
 
@@ -45,10 +41,8 @@ void on_ping(
   discord_create_message(client, msg->channel_id, &params, NULL);
 }
 
-void on_pong(
-    struct discord *client,
-    const struct discord_user *bot,
-    const struct discord_message *msg)
+void on_pong(struct discord *client, const struct discord_user *bot,
+             const struct discord_message *msg)
 {
   if (msg->author->bot) return; // ignore bots
 
@@ -56,7 +50,7 @@ void on_pong(
   discord_create_message(client, msg->channel_id, &params, NULL);
 }
 
-int main()
+int main(void)
 {
   struct discord *client = discord_config_init("./mybot_config.json");
 


### PR DESCRIPTION
## Orca
### WebSockets
- Replace clock() functions with time(), the first one is inaccurate. (44d2f8ef2fe7603bb1eb1162872f66bfcda39f2c)
### User-Agent
- Fixes regression of not de-referencing a pointer. (44d2f8ef2fe7603bb1eb1162872f66bfcda39f2c)
## Discord
### Ratelimiting
- Takes elapsed milliseconds into consideration if using `Date` header to calculate ratelimiting cooldown. (c508d8cafa9eabcaded0d0138483e236a1f02c3d)