### PR TITLE
Fix: Discord API HTTP_DELETE Content-Type

### DIFF
--- a/discord-adapter.c
+++ b/discord-adapter.c
@@ -334,6 +334,9 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
     ua_conn_add_header(conn, "Content-Type", "multipart/form-data");
     ua_conn_set_mime(conn, &cxt, &_discord_context_to_mime);
   }
+  else if (HTTP_DELETE) {
+    ua_conn_add_header(conn, "Content-Type", "application/octet-stream");
+  }
   else {
     ua_conn_add_header(conn, "Content-Type", "application/json");
   }
@@ -616,6 +619,9 @@ _discord_adapter_send(struct discord_adapter *adapter,
   if (HTTP_MIMEPOST == cxt->method) {
     ua_conn_add_header(cxt->conn, "Content-Type", "multipart/form-data");
     ua_conn_set_mime(cxt->conn, cxt, &_discord_context_to_mime);
+  }
+  else if (HTTP_DELETE == cxt->method) {
+    ua_conn_add_header(cxt->conn, "Content-Type", "application/octet-stream");
   }
   else {
     ua_conn_add_header(cxt->conn, "Content-Type", "application/json");

--- a/discord-adapter.c
+++ b/discord-adapter.c
@@ -334,7 +334,7 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
     ua_conn_add_header(conn, "Content-Type", "multipart/form-data");
     ua_conn_set_mime(conn, &cxt, &_discord_context_to_mime);
   }
-  else if (HTTP_DELETE) {
+  else if (HTTP_DELETE == method) {
     ua_conn_add_header(conn, "Content-Type", "application/octet-stream");
   }
   else {


### PR DESCRIPTION
Currently requests to the discord API that use HTTP_DELETE fail. These requests have a Content-Type of `application/json`. I assume that discord sees this and checks for validity before doing anything; because we don't actually send any content it sends back an error. 

This is a naive fix; I don't have extensive knowledge about the code base. If I omitted a content-type, the `application/json` seemed to be the default. The choice of `application/octet-stream` was chosen since that is the assumed type if Content-Type is omitted.

Before:
```
@@@_14_@@@
HTTP_SEND_DELETE [USER_AGENT #TID2599853568] - 2022-09-18T22:18:15.574Z - https://discord.com/api/v9/guilds/934856214544777227/bans/876529701215174656
User-Agent: Orca (https://github.com/cee-studio/orca)
Authorization: Bot OTQwMzM3Mjk0NzI3MDczNzkz.GLn14N.9r4aRy-0YpPKFLcHZrE6ZMOzyeWuFn2s9YjCIU
Content-Type: application/json

@@@_15_@@@
HTTP_RCV_BAD_REQUEST(400) [USER_AGENT #TID2599853568] - 2022-09-18T22:18:15.635Z - https://discord.com/api/v9/guilds/934856214544777227/bans/876529701215174656
date: Sun, 18 Sep 2022 21:18:15 GMT
content-type: application/json
content-length: 69
set-cookie: __dcfduid=68cd07e6379711ed80e1eed6101c701d; Expires=Fri, 17-Sep-2027 21:18:15 GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-envoy-upstream-service-time: 27
via: 1.1 google
alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
cf-cache-status: DYNAMIC
report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=d0nDSIxw9nbzlplw8ZPM8asjHvqHYGVRaifaVeAmMN1IIteY5%2Fi6Jz%2FZuTwARnVaP9wrxnipGRelFws1exs33ulWbqHyI76Ed9ealUc2POC%2FABx8RF%2B4XA%2F8x6ty"}],"group":"cf-nel","max_age":604800}
nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
x-content-type-options: nosniff
set-cookie: __sdcfduid=68cd07e6379711ed80e1eed6101c701dba0d24fb3c9041920788372df0708a8872e125808cb1e4c2d8c549859014d356; Expires=Fri, 17-Sep-2027 21:18:15 GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
set-cookie: __cfruid=895a19100fd455f0b900cbc08a782c7c33046d1f-1663535895; path=/; domain=.discord.com; HttpOnly; Secure; SameSite=None
server: cloudflare
cf-ray: 74cd1cf35ac9700d-IAD

{"code": 50109, "message": "The request body contains invalid JSON."}

```

After:
```
@@@_14_@@@
HTTP_SEND_DELETE [USER_AGENT #TID579853824] - 2022-09-18T22:15:57.744Z - https://discord.com/api/v9/guilds/934856214544777227/bans/876529701215174656
User-Agent: Orca (https://github.com/cee-studio/orca)
Authorization: Bot OTQwMzM3Mjk0NzI3MDczNzkz.GLn14N.9r4aRy-0YpPKFLcHZrE6ZMOzyeWuFn2s9YjCIU
Content-Type: application/octet-stream

@@@_15_@@@
HTTP_RCV_NO_CONTENT(204) [USER_AGENT #TID579853824] - 2022-09-18T22:15:57.952Z - https://discord.com/api/v9/guilds/934856214544777227/bans/876529701215174656
date: Sun, 18 Sep 2022 21:15:57 GMT
content-type: text/html; charset=utf-8
set-cookie: __dcfduid=16bc0114379711edaadf8eb625624e6d; Expires=Fri, 17-Sep-2027 21:15:57 GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-envoy-upstream-service-time: 173
via: 1.1 google
alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
cf-cache-status: DYNAMIC
report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=g7o15yF%2BtU2AZ8pmO9gixAmlPcjNUYbnQTpbJnkobVb3TAoFjusuqLq2oac%2BH4suGfM40ZRZYoPT99HNikmOC90ghng8pUz7nqH1ESjjFbu0Jwy%2FmwYKU2murNe4"}],"group":"cf-nel","max_age":604800}
nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
x-content-type-options: nosniff
set-cookie: __sdcfduid=16bc0114379711edaadf8eb625624e6d8698867f41d9dc4af46ad7ba03201f77d39233a2863df675e7094370ac7eb489; Expires=Fri, 17-Sep-2027 21:15:57 GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
set-cookie: __cfruid=33a42d957abd386e15ced05dc983348266cdf9dd-1663535757; path=/; domain=.discord.com; HttpOnly; Secure; SameSite=None
server: cloudflare
cf-ray: 74cd1995ed6205d6-IAD
```